### PR TITLE
fix: support single quote in stylesheet link hrefs

### DIFF
--- a/packages/eleventy-plugin-styles/src/constants.ts
+++ b/packages/eleventy-plugin-styles/src/constants.ts
@@ -1,4 +1,3 @@
 /** Match stylesheet link and get URL of file from HTML. */
 export const STYLESHEET_LINK_REGEXP =
-  /<link\s+[^>]*href="([^"]+\.(?:css|scss|sass))"[^>]*>/g;
-
+  /<link\s+[^>]*href=(?:'|")([^"]+\.(?:css|scss|sass))(?:'|")[^>]*>/g;


### PR DESCRIPTION
Fix for https://github.com/Halo-Lab/eleventy-plugin-styles/issues/3